### PR TITLE
DM-46313: Test PR with only changed notebooks

### DIFF
--- a/timeout.ipynb
+++ b/timeout.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "from time import sleep\n",
-    "sleep(6*60)"
+    "sleep(4*60)  # execution in 5 minutes should work"
    ]
   }
  ],

--- a/timeout.yaml
+++ b/timeout.yaml
@@ -4,4 +4,4 @@ description: This notebook times out.
 authors:
   - name: Jonathan Sick
 parameters: {}
-timeout: 400  # extra timeout
+timeout: 300


### PR DESCRIPTION
This is a check that Times Square only computes changed notebooks.

Reduce runtime of "timeout" — this notebook should now execute fine.